### PR TITLE
[CVE-2013-2208] Don't execute commands with --exec by default

### DIFF
--- a/doc/tpp.1
+++ b/doc/tpp.1
@@ -20,6 +20,8 @@ LaTeX conversion and more.
 .TP
 -l output.tex input.tpp converts tpp slides into tex 
 .TP
+-x allow usage of "--exec"
+.TP
 -v/--version display version number
 
 .SH KEYS

--- a/tpp.rb
+++ b/tpp.rb
@@ -725,9 +725,13 @@ class NcursesVisualizer < TppVisualizer
   end
 
   def do_exec(cmdline)
-    rc = Kernel.system(cmdline)
-    if not rc then
-      # @todo: add error message
+    if $execok then
+      rc = Kernel.system(cmdline)
+      if not rc then
+        # @todo: add error message
+      end
+    else
+      @screen.addstr("--exec disabled by default for security reasons. Use option -x to enable it.")
     end
   end
 
@@ -1683,6 +1687,7 @@ def usage
   $stderr.puts "\t -t <type>\tset filetype <type> as output format"
   $stderr.puts "\t -o <file>\twrite output to file <file>"
   $stderr.puts "\t -s <seconds>\twait <seconds> seconds between slides (with -t autoplay)"
+  $stderr.puts "\t -x\t\tallow parsing of --exec in input files"
   $stderr.puts "\t --version\tprint the version"
   $stderr.puts "\t --help\t\tprint this help"
   $stderr.puts "\n\t currently available types: ncurses (default), autoplay, latex, txt"
@@ -1699,6 +1704,7 @@ input = nil
 output = nil
 type = "ncurses"
 time = 1
+$execok = nil
 
 skip_next = false
 
@@ -1720,6 +1726,8 @@ ARGV.each_index do |i|
     elsif ARGV[i] == "-s" then
       time = ARGV[i+1].to_i
       skip_next = true
+    elsif ARGV[i] == "-x" then
+      $execok = 1
     elsif input == nil then
       input = ARGV[i]
     end


### PR DESCRIPTION
tpp's --exec feature is potentially a security risk when using with
presentations from untrusted sources. (Originally reported against tpp
in Debian at http://bugs.debian.org/706644)

This commit disables execution of --exec parameters by default and
adds an option -x to reenable the --exec feature only on explicit
request.
