### PR TITLE
Fixing ' '.ord problem on 1.8.x which doesn't have the method for strings

### DIFF
--- a/tpp.rb
+++ b/tpp.rb
@@ -1431,7 +1431,7 @@ class InteractiveController < TppController
             ch = @vis.get_key
             @vis.clear
             @vis.restore_screen(screen)
-          when :keyright, :keydown, ' '.ord
+          when :keyright, :keydown, 32
             if @cur_page + 1 < @pages.size and eop then
               @cur_page += 1
               @pages[@cur_page].reset_eop


### PR DESCRIPTION
Prevents crashes on 1.8.x
